### PR TITLE
Rewriting to use ldap3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ env:
   - DJANGO_VERSION=1.4
   - DJANGO_VERSION=1.8
 
-apt:
-  packages:
-    - libldap2-dev
-    - libsasl2-dev
-
 sudo: false
  
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "3.4"
 
 env:
-  - DJANGO_VERSION~=1.8
-  - DJANGO_VERSION~=1.11
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.11
 
 sudo: false
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ python:
   - "3.4"
 
 env:
-  - DJANGO_VERSION=1.4
-  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION~=1.8
+  - DJANGO_VERSION~=1.11
 
 sudo: false
  
 install: 
- - pip install Django==$DJANGO_VERSION
+ - pip install Django~=$DJANGO_VERSION
  - pip install .
  - pip install -r testing-ci/requirements.txt 
  - pip install pep8 pyflakes

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ sudo: false
 install: 
  - pip install Django~=$DJANGO_VERSION
  - pip install .
- - pip install -r testing-ci/requirements.txt 
  - pip install pep8 pyflakes
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 
-
 python:
   - "2.7"
+  - "3.4"
 
 env:
   - DJANGO_VERSION=1.4

--- a/django_auth_ldap_ad/backend.py
+++ b/django_auth_ldap_ad/backend.py
@@ -16,6 +16,9 @@ class LDAPBackendException(Exception):
 class LDAPBackend(object):
 
     def __init__(self):
+        # References are stored as instance variables so tests can replace
+        # these in the instance with fakes/mocks without affecting
+        # business logic
         self.connection = ldap3.Connection
         self.ldap_settings = LDAPSettings()
 

--- a/django_auth_ldap_ad/backend.py
+++ b/django_auth_ldap_ad/backend.py
@@ -1,4 +1,3 @@
-
 from ldap3 import Server, Connection, SASL, SUBTREE, ASYNC
 from django.contrib.auth.models import User, Group
 from ldap3.core.exceptions import LDAPInvalidCredentialsResult, LDAPException
@@ -63,8 +62,9 @@ class LDAPBackend(object):
             "client_strategy": self.client_strategy
         }
         kwargs.update(self.ldap_settings.CONNECTION_OPTIONS)
-            
+
         connection = Connection(**kwargs)
+
         if self.connection_hook is not None:
             self.connection_hook(connection)
         return connection

--- a/django_auth_ldap_ad/backend.py
+++ b/django_auth_ldap_ad/backend.py
@@ -72,10 +72,11 @@ class LDAPBackend(object):
 
     # Search for user, returns users info (dict)
     def ldap_search_user(self, connection, username, password):
+        attributes = ["memberOf"] + list(self.ldap_settings.USER_ATTR_MAP.values())
         ldap_result_id = connection.search(
             search_base=self.ldap_settings.SEARCH_DN,
             search_scope=SUBTREE,
-            attributes=["memberOf"],
+            attributes=attributes,
             search_filter=self.ldap_settings.SEARCH_FILTER % {
                 "user": username})
 

--- a/django_auth_ldap_ad/backend.py
+++ b/django_auth_ldap_ad/backend.py
@@ -73,15 +73,16 @@ class LDAPBackend(object):
     # Search for user, returns users info (dict)
     def ldap_search_user(self, connection, username, password):
         attributes = ["memberOf"] + list(self.ldap_settings.USER_ATTR_MAP.values())
-        ldap_result_id = connection.search(
+        if not connection.search(
             search_base=self.ldap_settings.SEARCH_DN,
             search_scope=SUBTREE,
             attributes=attributes,
             search_filter=self.ldap_settings.SEARCH_FILTER % {
-                "user": username})
+                "user": username}):
+            raise LDAPBackendException("Failure searching for user")
 
         result_entries = connection.entries
- 
+
         if len(result_entries) == 0:
             raise LDAPBackendException("No entries found!")
 

--- a/django_auth_ldap_ad/tests.py
+++ b/django_auth_ldap_ad/tests.py
@@ -27,24 +27,25 @@ class LDAPBackendTest(TestCase):
     def setUp(self):
         self.backend = backend.LDAPBackend()
         self.backend.connection = self._create_connection
+        self.last_connection = None
 
     def _create_connection(self, **kwargs):
         kwargs["client_strategy"] = MOCK_SYNC
         connection = Connection(**kwargs)
         connection.strategy.add_entry(*self.alice)
+        self.last_connection = connection
         return connection
 
     def _init_settings(self, **kwargs):
         self.backend.ldap_settings = TestSettings(**kwargs)
 
-    @unittest.expectedFailure
     def test_options(self):
         self._init_settings(
             SEARCH_DN="o=test",
-            CONNECTION_OPTIONS={'opt1': 'value1'}
+            CONNECTION_OPTIONS={'read_only': True}
         )
         self.backend.authenticate(username='alice', password='alicepw')
-        self.assertEqual(self.ldapobj.get_option('opt1'), 'value1')
+        self.assertEqual(self.last_connection.read_only, True)
 
     def test_server_uri_string(self):
         self._init_settings(

--- a/django_auth_ldap_ad/tests.py
+++ b/django_auth_ldap_ad/tests.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from ldap3 import Server, Connection, MOCK_ASYNC
+from ldap3 import MOCK_ASYNC
 from . import backend
 
 from django.test import TestCase
@@ -25,18 +25,14 @@ class LDAPBackendTest(TestCase):
                            "dc=test,cn=superuser,cn=extra,cn=fake,ou=foo",
                            "dc=test,cn=fakuser,cn=extra,cn=fake,ou=foo"]})
 
-    def setUp(self):
-        self.server = Server("MockServer")
-
     def _connection_hook(self, connection):
-        connection.strategy.add_entry(alice)
+        connection.strategy.add_entry(self.alice)
 
     def _init_settings(self, **kwargs):
         ldap_settings = TestSettings(**kwargs)
         self.backend = backend.LDAPBackend(client_strategy=MOCK_ASYNC,
                                            ldap_settings=ldap_settings,
                                            connection_hook=self._connection_hook)
-
 
     @unittest.expectedFailure
     def test_options(self):

--- a/django_auth_ldap_ad/tests.py
+++ b/django_auth_ldap_ad/tests.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from ldap3 import MOCK_SYNC, Connection
+import ldap3
 from . import backend
 
 from django.test import TestCase
@@ -30,8 +30,8 @@ class LDAPBackendTest(TestCase):
         self.last_connection = None
 
     def _create_connection(self, **kwargs):
-        kwargs["client_strategy"] = MOCK_SYNC
-        connection = Connection(**kwargs)
+        kwargs["client_strategy"] = ldap3.MOCK_SYNC
+        connection = ldap3.Connection(**kwargs)
         connection.strategy.add_entry(*self.alice)
         self.last_connection = connection
         return connection

--- a/django_auth_ldap_ad/tests.py
+++ b/django_auth_ldap_ad/tests.py
@@ -3,7 +3,6 @@ from ldap3 import MOCK_SYNC, Connection
 from . import backend
 
 from django.test import TestCase
-import unittest
 
 from django.contrib.auth.models import User, Group
 
@@ -14,6 +13,7 @@ class TestSettings(backend.LDAPSettings):
         for name, default in self.defaults.items():
             value = kwargs.get(name, default)
             setattr(self, name, value)
+
 
 class LDAPBackendTest(TestCase):
     top = ('o=test', {'o': 'test'})

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     version = "2.0.0",
     packages = ["django_auth_ldap_ad"],
     long_description = long_description,
-    install_requires = ["python-ldap", "Django>=1.4,<=1.9", "six"]
+    install_requires = ["ldap3", "Django>=1.4,<=1.8", "six"]
 )

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     version = "2.0.0",
     packages = ["django_auth_ldap_ad"],
     long_description = long_description,
-    install_requires = ["ldap3", "Django>=1.4,<=1.8", "six"]
+    install_requires = ["ldap3", "Django>=1.8,<1.12", "six"]
 )

--- a/testing-ci/requirements.txt
+++ b/testing-ci/requirements.txt
@@ -1,2 +1,0 @@
-mockldap
-


### PR DESCRIPTION
Rewriting codebase to use ldap3 instead of python-ldap. Some old options for temporarily removed until replacements can be figured out.